### PR TITLE
Fix shell command example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ If you would rather use a shell command
 # ...
 plugins:
     raw:
-        command: ['rsync', '-a', './src/raw/', './out/']
+        raw:
+            command: ['rsync', '-a', './src/raw/', './out/']
 # ...
 ```
 


### PR DESCRIPTION
The raw plugin config expects to receive objects. The README example for a shell command just passes the array of commands, making raw's check for [`target.command`](﻿https://github.com/docpad/docpad-plugin-raw/blob/master/src/raw.plugin.coffee#L36) impossible and producing the error `﻿﻿﻿﻿TypeError: Arguments to path.join must be strings`.
