### PR TITLE
Fixes error with multiple targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
     "docpad": "6"
   },
   "dependencies": {
-    "ncp": "~0.5.0",
+    "async": "~0.3.0",
     "eachr": "~2.0.2",
-    "safeps": "~2.2.11",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "ncp": "~0.5.0",
+    "safeps": "~2.2.11"
   },
   "devDependencies": {
     "projectz": "~0.3.9",


### PR DESCRIPTION
If using multiple targets, the following error could occur: "A task's completion callback has fired
when the task was already in a completed state"

The PR also builds on @ahdinosaur's pull request #6.
